### PR TITLE
WIP: feature/open-in-editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/*
+.idea
+tags

--- a/vim.go
+++ b/vim.go
@@ -89,6 +89,15 @@ func (o *opVim) handleVimNormalMovement(r rune, readNext func() rune) (t rune, h
 		default:
 			rb.MoveTo(next, prevChar, reverse)
 		}
+	case 'v':
+		next := readNext()
+		switch next {
+		case 'v':
+			rb.openInEditor()
+		default:
+			return t, false
+		}
+		return t, true
 	default:
 		return r, false
 	}


### PR DESCRIPTION
This feature allows users to use the key combination `Esc + vv` to edit
the contents of the current prompt in an editor (determined by the
$EDITOR variable defaulted to `vi`).